### PR TITLE
Add wireguard tag; bump twingate UID/GID to 65532

### DIFF
--- a/ix-dev/community/tailscale/app.yaml
+++ b/ix-dev/community/tailscale/app.yaml
@@ -25,6 +25,7 @@ icon: https://media.sys.truenas.net/apps/tailscale/icons/icon.png
 keywords:
 - vpn
 - tailscale
+- wireguard
 lib_version: 2.1.77
 lib_version_hash: 1837f8e69ae1adc313330c3b1c2615e9b4d03c5459d657a5898bae78090f8195
 maintainers:

--- a/ix-dev/community/tailscale/item.yaml
+++ b/ix-dev/community/tailscale/item.yaml
@@ -5,3 +5,4 @@ screenshots: []
 tags:
 - vpn
 - tailscale
+- wireguard

--- a/ix-dev/community/twingate-connector/app.yaml
+++ b/ix-dev/community/twingate-connector/app.yaml
@@ -20,14 +20,14 @@ maintainers:
   url: https://www.truenas.com/
 name: twingate-connector
 run_as_context:
-- description: Container [twingate-connector] can run as any non-root user and group.
-  gid: 568
-  group_name: Host group is [apps]
-  uid: 568
-  user_name: Host user is [apps]
+- description: Container [twingate-connector] run as non-root user and group.
+  gid: 65532
+  group_name: Host group is [nonroot]
+  uid: 65532
+  user_name: Host user is [nonroot]
 screenshots: []
 sources:
 - https://www.twingate.com/
 title: Twingate Connector
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/twingate-connector/questions.yaml
+++ b/ix-dev/community/twingate-connector/questions.yaml
@@ -102,7 +102,7 @@ questions:
           schema:
             type: int
             min: 568
-            default: 568
+            default: 65532
             required: true
         - variable: group
           label: Group ID
@@ -110,7 +110,7 @@ questions:
           schema:
             type: int
             min: 568
-            default: 568
+            default: 65532
             required: true
 
   - variable: network

--- a/ix-dev/community/twingate-connector/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/twingate-connector/templates/test_values/basic-values.yaml
@@ -13,8 +13,8 @@ twingate:
   additional_envs: []
 
 run_as:
-  user: 568
-  group: 568
+  user: 65532
+  group: 65532
 
 network:
   host_network: true


### PR DESCRIPTION
Add 'wireguard' keyword to Tailscale app and item metadata. Update twingate-connector to run as a non-root user/group by changing run_as_context UID/GID to 65532 and renaming host user/group to 'nonroot'; adjust related question defaults and test_values accordingly. Also simplify the run_as description and bump the twingate-connector version to 1.0.1.

# Pull Request

⚠️⚠️⚠️ **BEFORE CREATING THE PR** ⚠️⚠️⚠️

Please go to the **Preview** tab and select the appropriate template: 

* [🚀 App Addition](?expand=1&template=app_addition.md)